### PR TITLE
Deep copy needed when constructing Widget Model, rather than shallow copy

### DIFF
--- a/src/models/widgetModel.js
+++ b/src/models/widgetModel.js
@@ -20,17 +20,19 @@ angular.module('ui.dashboard')
   .factory('WidgetModel', function () {
     // constructor for widget model instances
     function WidgetModel(Class, overrides) {
+      var defaults = {
+          title: 'Widget',
+          name: Class.name,
+          attrs: Class.attrs,
+          dataAttrName: Class.dataAttrName,
+          dataTypes: Class.dataTypes,
+          dataModelType: Class.dataModelType,
+          //AW Need deep copy of options to support widget options editing
+          dataModelOptions: Class.dataModelOptions,
+          style: Class.style
+        };
       overrides = overrides || {};
-      angular.extend(this, {
-        title: 'Widget',
-        name: Class.name,
-        attrs: Class.attrs,
-        dataAttrName: Class.dataAttrName,
-        dataTypes: Class.dataTypes,
-        dataModelType: Class.dataModelType,
-        dataModelOptions: Class.dataModelOptions,
-        style: Class.style
-      }, overrides);
+      angular.extend(this, angular.copy(defaults), overrides);
       this.style = this.style || { width: '33%' };
       this.setWidth(this.style.width);
 


### PR DESCRIPTION
As per this issue https://github.com/nickholub/angular-ui-dashboard/issues/5

This solution solves the problem for my graphite dashboard and in practice seems to work.

Hopefully my change for shallow vs deep cloning make sense?

The only use case that I know I ignored is what if "overrides" contains objects which need deep copy also...haven't seen the use case for "overrides" yet, so I simply don't know!
