### PR TITLE
Fixed bug with default widgets not creating unsaved status

### DIFF
--- a/dist/angular-ui-dashboard.js
+++ b/dist/angular-ui-dashboard.js
@@ -205,6 +205,7 @@ angular.module('ui.dashboard')
          */
         scope.resetWidgetsToDefault = function () {
           scope.loadWidgets(scope.defaultWidgets);
+          scope.saveDashboard();
         };
 
         // Set default widgets array

--- a/src/directives/dashboard.js
+++ b/src/directives/dashboard.js
@@ -205,6 +205,7 @@ angular.module('ui.dashboard')
          */
         scope.resetWidgetsToDefault = function () {
           scope.loadWidgets(scope.defaultWidgets);
+          scope.saveDashboard();
         };
 
         // Set default widgets array


### PR DESCRIPTION
I love the new explicit save stuff, and I found a small issue where the unsaved changes state wasn't being updated when the default widgets button was being pressed.   
