### PR TITLE
Added loadDashboard external API method

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ key | type | default value | required | description
  storageHash | String | '' | no | This is used to validate/invalidate loaded state. See the **Persistence** section below.
  explicitSave | Boolean | false | no | The dashboard will not automatically save to storage for every change. Saves must instead be called explicitly using the `saveDashboard` method that is attached to the option event upon initialization.
 
-Upon instantiation, this options object is endowed with a few API methods for use by outside code: `addWidget`, `loadWidgets`, and `saveDashboard`. 
+Upon instantiation, this options object is endowed with a few API methods for use by outside code: `addWidget`, `loadWidgets`, `saveDashboard` and `loadDashboard`. 
 
 ### Widget Definition Objects
 

--- a/dist/angular-ui-dashboard.js
+++ b/dist/angular-ui-dashboard.js
@@ -32,7 +32,7 @@ angular.module('ui.dashboard')
           },
           handle: '.widget-header'
         };
-        
+
       }],
       link: function (scope, element, attrs) {
         // Extract options the dashboard="" attribute
@@ -40,7 +40,7 @@ angular.module('ui.dashboard')
 
         // Save default widget config for reset
         scope.defaultWidgets = scope.options.defaultWidgets;
-        
+
         //scope.widgetDefs = scope.options.widgetDefinitions;
         scope.widgetDefs = new WidgetDefCollection(scope.options.widgetDefinitions);
         var count = 1;
@@ -208,9 +208,6 @@ angular.module('ui.dashboard')
           scope.saveDashboard();
         };
 
-        // Set default widgets array
-        var savedWidgetDefs = scope.dashboardState.load();
-
         // Success handler
         function handleStateLoad(saved) {
           if (saved && saved.length) {
@@ -220,22 +217,29 @@ angular.module('ui.dashboard')
           }
         }
 
-        if (savedWidgetDefs instanceof Array) {
-          handleStateLoad(savedWidgetDefs);
-        }
-        else if (savedWidgetDefs && typeof savedWidgetDefs === 'object' && typeof savedWidgetDefs.then === 'function') {
-          savedWidgetDefs.then(handleStateLoad, handleStateLoad);
-        }
-        else {
-          handleStateLoad();
-        }
+        scope.loadSavedWidgets = function() {
+        // Set default widgets array
+          var savedWidgetDefs = scope.dashboardState.load();
+
+          if (savedWidgetDefs instanceof Array) {
+            handleStateLoad(savedWidgetDefs);
+          }
+          else if (savedWidgetDefs && typeof savedWidgetDefs === 'object' && typeof savedWidgetDefs.then === 'function') {
+            savedWidgetDefs.then(handleStateLoad, handleStateLoad);
+          }
+          else {
+            handleStateLoad();
+          }
+        };
+
+        scope.loadSavedWidgets();
 
         // expose functionality externally
         // functions are appended to the provided dashboard options
         scope.options.addWidget = scope.addWidget;
         scope.options.loadWidgets = scope.loadWidgets;
         scope.options.saveDashboard = scope.externalSaveDashboard;
-
+        scope.options.loadDashboard = scope.loadSavedWidgets;
 
         // save state
         scope.$on('widgetChanged', function (event) {

--- a/src/directives/dashboard.js
+++ b/src/directives/dashboard.js
@@ -32,7 +32,7 @@ angular.module('ui.dashboard')
           },
           handle: '.widget-header'
         };
-        
+
       }],
       link: function (scope, element, attrs) {
         // Extract options the dashboard="" attribute
@@ -40,7 +40,7 @@ angular.module('ui.dashboard')
 
         // Save default widget config for reset
         scope.defaultWidgets = scope.options.defaultWidgets;
-        
+
         //scope.widgetDefs = scope.options.widgetDefinitions;
         scope.widgetDefs = new WidgetDefCollection(scope.options.widgetDefinitions);
         var count = 1;
@@ -208,9 +208,6 @@ angular.module('ui.dashboard')
           scope.saveDashboard();
         };
 
-        // Set default widgets array
-        var savedWidgetDefs = scope.dashboardState.load();
-
         // Success handler
         function handleStateLoad(saved) {
           if (saved && saved.length) {
@@ -220,22 +217,29 @@ angular.module('ui.dashboard')
           }
         }
 
-        if (savedWidgetDefs instanceof Array) {
-          handleStateLoad(savedWidgetDefs);
-        }
-        else if (savedWidgetDefs && typeof savedWidgetDefs === 'object' && typeof savedWidgetDefs.then === 'function') {
-          savedWidgetDefs.then(handleStateLoad, handleStateLoad);
-        }
-        else {
-          handleStateLoad();
-        }
+        scope.loadSavedWidgets = function() {
+        // Set default widgets array
+          var savedWidgetDefs = scope.dashboardState.load();
+
+          if (savedWidgetDefs instanceof Array) {
+            handleStateLoad(savedWidgetDefs);
+          }
+          else if (savedWidgetDefs && typeof savedWidgetDefs === 'object' && typeof savedWidgetDefs.then === 'function') {
+            savedWidgetDefs.then(handleStateLoad, handleStateLoad);
+          }
+          else {
+            handleStateLoad();
+          }
+        };
+
+        scope.loadSavedWidgets();
 
         // expose functionality externally
         // functions are appended to the provided dashboard options
         scope.options.addWidget = scope.addWidget;
         scope.options.loadWidgets = scope.loadWidgets;
         scope.options.saveDashboard = scope.externalSaveDashboard;
-
+        scope.options.loadDashboard = scope.loadSavedWidgets;
 
         // save state
         scope.$on('widgetChanged', function (event) {


### PR DESCRIPTION
Ok - I hope I'm not wearing you guys out with pull requests ;-)

I wrapped the logic that loads the initial state of the dashboard into a function called loadDashboard and also exposed that as an external api to the dashboardOptions.  My motivation was the ability to be able to roll back the dashboard to the previously saved state without forcing the user to do a full page refresh.  I didn't add this into the default set of buttons, but I did document the fact this method is available.  

Let me know what you think.
