### PR TITLE
Fix template-url attribute in dashboard-layouts

### DIFF
--- a/template/dashboard-layouts.html
+++ b/template/dashboard-layouts.html
@@ -16,4 +16,4 @@
         </a>
     </li>
 </ul>
-<div ng-repeat="layout in layouts | filter:isActive" dashboard="layout.dashboard" templateUrl="template/dashboard.html"></div>
+<div ng-repeat="layout in layouts | filter:isActive" dashboard="layout.dashboard" template-url="template/dashboard.html"></div>


### PR DESCRIPTION
The code as-is still works to load the default dashboard layout, I presume because it's a hardcoded fallback somewhere else, but when copying this file to modify it (and point to a custom dashboard.html template), the malformed templateUrl attribute is ignored, and the template specified by templateUrl isn't loaded - changing it to template-url allows the specified template to actually load.
