### PR TITLE
Wrong property name when setting height of widget - bug fix

### DIFF
--- a/src/components/models/WidgetModel.js
+++ b/src/components/models/WidgetModel.js
@@ -82,8 +82,8 @@ angular.module('ui.dashboard')
       },
 
       setHeight: function (height) {
-        this.contentStyle.height = height;
-        this.updateSize(this.contentStyle);
+        this.containerStyle.height = height;
+        this.updateSize(this.containerStyle);
       },
 
       setStyle: function (style) {


### PR DESCRIPTION
Because styles applied on widget are located in `widget.containerStyle` setting `this.contentStyle.height` in `setHeight` method does nothing. I updated property name in method `setHeight` to `containerStyle`.