### PR TITLE
Update dashboard.js

### DIFF
--- a/src/components/directives/dashboard/dashboard.js
+++ b/src/components/directives/dashboard/dashboard.js
@@ -221,8 +221,12 @@ angular.module('ui.dashboard')
         /**
          * Wraps saveDashboard for external use.
          */
-        scope.externalSaveDashboard = function() {
-          scope.saveDashboard(true);
+        scope.externalSaveDashboard = function(force) {
+          if (angular.isDefined(force)) {
+            scope.saveDashboard(force);
+          } else {
+            scope.saveDashboard(true);
+          }
         };
 
         /**


### PR DESCRIPTION
Make it possible to call "externalSaveDashboard" with force "false". Default is always and still true.