### PR TITLE
replace $modal with $uibModal

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "dependencies": {
     "bootstrap": "~3.3.1",
-    "angular-bootstrap": "0.12.x",
+    "angular-bootstrap": "^1.0.0",
     "angular": "~1.3",
     "angular-ui-sortable": "~0.13.3",
     "lodash": "~3.1"

--- a/dist/malhar-angular-dashboard.js
+++ b/dist/malhar-angular-dashboard.js
@@ -19,7 +19,7 @@ angular.module('ui.dashboard', ['ui.bootstrap', 'ui.sortable']);
 
 angular.module('ui.dashboard')
 
-  .directive('dashboard', ['WidgetModel', 'WidgetDefCollection', '$modal', 'DashboardState', '$log', function (WidgetModel, WidgetDefCollection, $modal, DashboardState, $log) {
+  .directive('dashboard', ['WidgetModel', 'WidgetDefCollection', '$uibModal', 'DashboardState', '$log', function (WidgetModel, WidgetDefCollection, $uibModal, DashboardState, $log) {
 
     return {
       restrict: 'A',
@@ -139,7 +139,7 @@ angular.module('ui.dashboard')
          */
         scope.openWidgetSettings = function (widget) {
 
-          // Set up $modal options 
+          // Set up $uibModal options 
           var options = _.defaults(
             { scope: scope },
             widget.settingsModalOptions,
@@ -153,7 +153,7 @@ angular.module('ui.dashboard')
           };
           
           // Create the modal
-          var modalInstance = $modal.open(options);
+          var modalInstance = $uibModal.open(options);
           var onClose = widget.onSettingsClose || scope.options.onSettingsClose;
           var onDismiss = widget.onSettingsDismiss || scope.options.onSettingsDismiss;
 
@@ -614,8 +614,8 @@ angular.module('ui.dashboard')
 'use strict';
 
 angular.module('ui.dashboard')
-  .directive('dashboardLayouts', ['LayoutStorage', '$timeout', '$modal',
-    function(LayoutStorage, $timeout, $modal) {
+  .directive('dashboardLayouts', ['LayoutStorage', '$timeout', '$uibModal',
+    function(LayoutStorage, $timeout, $uibModal) {
       return {
         scope: true,
         templateUrl: function(element, attr) {
@@ -650,7 +650,7 @@ angular.module('ui.dashboard')
             var current = layoutStorage.getActiveLayout();
 
             if (current && current.dashboard.unsavedChangeCount) {
-              var modalInstance = $modal.open({
+              var modalInstance = $uibModal.open({
                 templateUrl: 'template/SaveChangesModal.html',
                 resolve: {
                   layout: function() {
@@ -762,17 +762,17 @@ angular.module('ui.dashboard')
 'use strict';
 
 angular.module('ui.dashboard')
-  .controller('SaveChangesModalCtrl', ['$scope', '$modalInstance', 'layout', function ($scope, $modalInstance, layout) {
+  .controller('SaveChangesModalCtrl', ['$scope', '$uibModalInstance', 'layout', function ($scope, $uibModalInstance, layout) {
     
     // add layout to scope
     $scope.layout = layout;
 
     $scope.ok = function () {
-      $modalInstance.close();
+      $uibModalInstance.close();
     };
 
     $scope.cancel = function () {
-      $modalInstance.dismiss();
+      $uibModalInstance.dismiss();
     };
   }]);
 /*
@@ -794,7 +794,7 @@ angular.module('ui.dashboard')
 'use strict';
 
 angular.module('ui.dashboard')
-  .controller('WidgetSettingsCtrl', ['$scope', '$modalInstance', 'widget', function ($scope, $modalInstance, widget) {
+  .controller('WidgetSettingsCtrl', ['$scope', '$uibModalInstance', 'widget', function ($scope, $uibModalInstance, widget) {
     // add widget to scope
     $scope.widget = widget;
 
@@ -802,11 +802,11 @@ angular.module('ui.dashboard')
     $scope.result = jQuery.extend(true, {}, widget);
 
     $scope.ok = function () {
-      $modalInstance.close($scope.result);
+      $uibModalInstance.close($scope.result);
     };
 
     $scope.cancel = function () {
-      $modalInstance.dismiss('cancel');
+      $uibModalInstance.dismiss('cancel');
     };
   }]);
 /*
@@ -968,10 +968,11 @@ angular.module('ui.dashboard')
       def = convertToDefinition(def);
       this.push(def);
       this.map[def.name] = def;
-    }
+    };
 
     return WidgetDefCollection;
   });
+
 /*
  * Copyright (c) 2014 DataTorrent, Inc. ALL Rights Reserved.
  *

--- a/src/app/customWidgetSettings.js
+++ b/src/app/customWidgetSettings.js
@@ -70,7 +70,7 @@ angular.module('app')
       storageId: 'custom-settings',
 
       /*
-      // Overrides default $modal options.
+      // Overrides default $uibModal options.
       // This can also be set on individual
       // widget definition objects (see above).
       settingsModalOptions: {
@@ -83,7 +83,7 @@ angular.module('app')
         //
         // controller: 'CustomSettingsModalCtrl'
         //
-        // Other options passed to $modal.open can be put here,
+        // Other options passed to $uibModal.open can be put here,
         // eg:
         //
         // backdrop: false,
@@ -114,7 +114,7 @@ angular.module('app')
       }
     };
   })
-  .controller('WidgetSpecificSettingsCtrl', function ($scope, $modalInstance, widget) {
+  .controller('WidgetSpecificSettingsCtrl', function ($scope, $uibModalInstance, widget) {
     // add widget to scope
     $scope.widget = widget;
 
@@ -123,11 +123,11 @@ angular.module('app')
 
     $scope.ok = function () {
       console.log('calling ok from widget-specific settings controller!');
-      $modalInstance.close($scope.result);
+      $uibModalInstance.close($scope.result);
     };
 
     $scope.cancel = function () {
       console.log('calling cancel from widget-specific settings controller!');
-      $modalInstance.dismiss('cancel');
+      $uibModalInstance.dismiss('cancel');
     };
   })

--- a/src/components/directives/dashboard/WidgetSettingsCtrl.js
+++ b/src/components/directives/dashboard/WidgetSettingsCtrl.js
@@ -17,7 +17,7 @@
 'use strict';
 
 angular.module('ui.dashboard')
-  .controller('WidgetSettingsCtrl', ['$scope', '$modalInstance', 'widget', function ($scope, $modalInstance, widget) {
+  .controller('WidgetSettingsCtrl', ['$scope', '$uibModalInstance', 'widget', function ($scope, $uibModalInstance, widget) {
     // add widget to scope
     $scope.widget = widget;
 
@@ -25,10 +25,10 @@ angular.module('ui.dashboard')
     $scope.result = jQuery.extend(true, {}, widget);
 
     $scope.ok = function () {
-      $modalInstance.close($scope.result);
+      $uibModalInstance.close($scope.result);
     };
 
     $scope.cancel = function () {
-      $modalInstance.dismiss('cancel');
+      $uibModalInstance.dismiss('cancel');
     };
   }]);

--- a/src/components/directives/dashboard/dashboard.js
+++ b/src/components/directives/dashboard/dashboard.js
@@ -19,7 +19,7 @@ angular.module('ui.dashboard', ['ui.bootstrap', 'ui.sortable']);
 
 angular.module('ui.dashboard')
 
-  .directive('dashboard', ['WidgetModel', 'WidgetDefCollection', '$modal', 'DashboardState', '$log', function (WidgetModel, WidgetDefCollection, $modal, DashboardState, $log) {
+  .directive('dashboard', ['WidgetModel', 'WidgetDefCollection', '$uibModal', 'DashboardState', '$log', function (WidgetModel, WidgetDefCollection, $uibModal, DashboardState, $log) {
 
     return {
       restrict: 'A',
@@ -139,7 +139,7 @@ angular.module('ui.dashboard')
          */
         scope.openWidgetSettings = function (widget) {
 
-          // Set up $modal options 
+          // Set up $uibModal options 
           var options = _.defaults(
             { scope: scope },
             widget.settingsModalOptions,
@@ -153,7 +153,7 @@ angular.module('ui.dashboard')
           };
           
           // Create the modal
-          var modalInstance = $modal.open(options);
+          var modalInstance = $uibModal.open(options);
           var onClose = widget.onSettingsClose || scope.options.onSettingsClose;
           var onDismiss = widget.onSettingsDismiss || scope.options.onSettingsDismiss;
 

--- a/src/components/directives/dashboard/dashboard.spec.js
+++ b/src/components/directives/dashboard/dashboard.spec.js
@@ -37,7 +37,7 @@ describe('Directive: dashboard', function () {
 
       }
     };
-    $provide.value('$modal', mockModal);
+    $provide.value('$uibModal', mockModal);
     $provide.value('$log', mockLog);
   }));
 
@@ -461,7 +461,7 @@ describe('Directive: dashboard', function () {
       expect(typeof childScope.openWidgetSettings).toEqual('function');
     });
 
-    it('should call $modal.open with default options', function() {
+    it('should call $uibModal.open with default options', function() {
       var widget = {};
       spyOn(mockModal, 'open').and.returnValue({
         result: { then: function(fn) {} }

--- a/src/components/directives/dashboardLayouts/SaveChangesModalCtrl.js
+++ b/src/components/directives/dashboardLayouts/SaveChangesModalCtrl.js
@@ -17,16 +17,16 @@
 'use strict';
 
 angular.module('ui.dashboard')
-  .controller('SaveChangesModalCtrl', ['$scope', '$modalInstance', 'layout', function ($scope, $modalInstance, layout) {
+  .controller('SaveChangesModalCtrl', ['$scope', '$uibModalInstance', 'layout', function ($scope, $uibModalInstance, layout) {
     
     // add layout to scope
     $scope.layout = layout;
 
     $scope.ok = function () {
-      $modalInstance.close();
+      $uibModalInstance.close();
     };
 
     $scope.cancel = function () {
-      $modalInstance.dismiss();
+      $uibModalInstance.dismiss();
     };
   }]);

--- a/src/components/directives/dashboardLayouts/dashboardLayouts.js
+++ b/src/components/directives/dashboardLayouts/dashboardLayouts.js
@@ -17,8 +17,8 @@
 'use strict';
 
 angular.module('ui.dashboard')
-  .directive('dashboardLayouts', ['LayoutStorage', '$timeout', '$modal',
-    function(LayoutStorage, $timeout, $modal) {
+  .directive('dashboardLayouts', ['LayoutStorage', '$timeout', '$uibModal',
+    function(LayoutStorage, $timeout, $uibModal) {
       return {
         scope: true,
         templateUrl: function(element, attr) {
@@ -53,7 +53,7 @@ angular.module('ui.dashboard')
             var current = layoutStorage.getActiveLayout();
 
             if (current && current.dashboard.unsavedChangeCount) {
-              var modalInstance = $modal.open({
+              var modalInstance = $uibModal.open({
                 templateUrl: 'template/SaveChangesModal.html',
                 resolve: {
                   layout: function() {

--- a/src/components/directives/dashboardLayouts/dashboardLayouts.spec.js
+++ b/src/components/directives/dashboardLayouts/dashboardLayouts.spec.js
@@ -33,7 +33,7 @@ describe('Directive: dashboard-layouts', function () {
     $mockTimeout = function(fn, delay) {
       toFn = fn;
     };
-    $provide.value('$modal', $mockModal);
+    $provide.value('$uibModal', $mockModal);
     $provide.value('$timeout', $mockTimeout);
   }));
 


### PR DESCRIPTION
The library doesn't work with the current angular-ui-bootstrap because they replaces all `$modal` occurrences with `$uibModal`. The PR fixes that and updates the dependencies.