### PR TITLE
Add min width for widgets

### DIFF
--- a/dist/malhar-angular-dashboard.js
+++ b/dist/malhar-angular-dashboard.js
@@ -282,6 +282,8 @@ angular.module('ui.dashboard')
         scope.options.saveDashboard = scope.externalSaveDashboard;
         scope.options.removeWidget = scope.removeWidget;
         scope.options.openWidgetSettings = scope.openWidgetSettings;
+        scope.options.clear = scope.clear;
+        scope.options.resetWidgetsToDefault = scope.resetWidgetsToDefault
 
         // save state
         scope.$on('widgetChanged', function (event) {

--- a/dist/malhar-angular-dashboard.js
+++ b/dist/malhar-angular-dashboard.js
@@ -316,186 +316,6 @@ $templateCache.put("components/directives/dashboardLayouts/dashboardLayouts.html
 'use strict';
 
 angular.module('ui.dashboard')
-  .directive('dashboardLayouts', ['LayoutStorage', '$timeout', '$uibModal',
-    function(LayoutStorage, $timeout, $uibModal) {
-      return {
-        scope: true,
-        templateUrl: function(element, attr) {
-          return attr.templateUrl ? attr.templateUrl : 'components/directives/dashboardLayouts/dashboardLayouts.html';
-        },
-        link: function(scope, element, attrs) {
-
-          scope.options = scope.$eval(attrs.dashboardLayouts);
-
-          var layoutStorage = new LayoutStorage(scope.options);
-
-          scope.layouts = layoutStorage.layouts;
-
-          scope.createNewLayout = function() {
-            var newLayout = {
-              title: 'Custom',
-              defaultWidgets: scope.options.defaultWidgets || []
-            };
-            layoutStorage.add(newLayout);
-            scope.makeLayoutActive(newLayout);
-            layoutStorage.save();
-            return newLayout;
-          };
-
-          scope.removeLayout = function(layout) {
-            layoutStorage.remove(layout);
-            layoutStorage.save();
-          };
-
-          scope.makeLayoutActive = function(layout) {
-
-            var current = layoutStorage.getActiveLayout();
-
-            if (current && current.dashboard.unsavedChangeCount) {
-              var modalInstance = $uibModal.open({
-                templateUrl: 'template/SaveChangesModal.html',
-                resolve: {
-                  layout: function() {
-                    return layout;
-                  }
-                },
-                controller: 'SaveChangesModalCtrl'
-              });
-
-              // Set resolve and reject callbacks for the result promise
-              modalInstance.result.then(
-                function() {
-                  current.dashboard.saveDashboard();
-                  scope._makeLayoutActive(layout);
-                },
-                function() {
-                  scope._makeLayoutActive(layout);
-                }
-              );
-            } else {
-              scope._makeLayoutActive(layout);
-            }
-
-          };
-
-          scope._makeLayoutActive = function(layout) {
-            angular.forEach(scope.layouts, function(l) {
-              if (l !== layout) {
-                l.active = false;
-              } else {
-                l.active = true;
-              }
-            });
-            layoutStorage.save();
-          };
-
-          scope.isActive = function(layout) {
-            return !!layout.active;
-          };
-
-          scope.editTitle = function(layout) {
-            if (layout.locked) {
-              return;
-            }
-
-            var input = element.find('input[data-layout="' + layout.id + '"]');
-            layout.editingTitle = true;
-
-            $timeout(function() {
-              input.focus()[0].setSelectionRange(0, 9999);
-            });
-          };
-
-          // saves whatever is in the title input as the new title
-          scope.saveTitleEdit = function(layout) {
-            layout.editingTitle = false;
-            layoutStorage.save();
-          };
-
-          scope.options.saveLayouts = function() {
-            layoutStorage.save(true);
-          };
-          scope.options.addWidget = function() {
-            var layout = layoutStorage.getActiveLayout();
-            if (layout) {
-              layout.dashboard.addWidget.apply(layout.dashboard, arguments);
-            }
-          };
-          scope.options.loadWidgets = function() {
-            var layout = layoutStorage.getActiveLayout();
-            if (layout) {
-              layout.dashboard.loadWidgets.apply(layout.dashboard, arguments);
-            }
-          };
-          scope.options.saveDashboard = function() {
-            var layout = layoutStorage.getActiveLayout();
-            if (layout) {
-              layout.dashboard.saveDashboard.apply(layout.dashboard, arguments);
-            }
-          };
-
-          var sortableDefaults = {
-            stop: function() {
-              scope.options.saveLayouts();
-            },
-            distance: 5
-          };
-          scope.sortableOptions = angular.extend({}, sortableDefaults, scope.options.sortableOptions || {});
-        }
-      };
-    }
-  ]);
-/*
- * Copyright (c) 2014 DataTorrent, Inc. ALL Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-'use strict';
-
-angular.module('ui.dashboard')
-  .controller('SaveChangesModalCtrl', ['$scope', '$uibModalInstance', 'layout', function ($scope, $uibModalInstance, layout) {
-    
-    // add layout to scope
-    $scope.layout = layout;
-
-    $scope.ok = function () {
-      $uibModalInstance.close();
-    };
-
-    $scope.cancel = function () {
-      $uibModalInstance.dismiss();
-    };
-  }]);
-/*
- * Copyright (c) 2014 DataTorrent, Inc. ALL Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-'use strict';
-
-angular.module('ui.dashboard')
   .directive('widget', ['$injector', function ($injector) {
 
     return {
@@ -798,6 +618,186 @@ angular.module('ui.dashboard')
 'use strict';
 
 angular.module('ui.dashboard')
+  .directive('dashboardLayouts', ['LayoutStorage', '$timeout', '$uibModal',
+    function(LayoutStorage, $timeout, $uibModal) {
+      return {
+        scope: true,
+        templateUrl: function(element, attr) {
+          return attr.templateUrl ? attr.templateUrl : 'components/directives/dashboardLayouts/dashboardLayouts.html';
+        },
+        link: function(scope, element, attrs) {
+
+          scope.options = scope.$eval(attrs.dashboardLayouts);
+
+          var layoutStorage = new LayoutStorage(scope.options);
+
+          scope.layouts = layoutStorage.layouts;
+
+          scope.createNewLayout = function() {
+            var newLayout = {
+              title: 'Custom',
+              defaultWidgets: scope.options.defaultWidgets || []
+            };
+            layoutStorage.add(newLayout);
+            scope.makeLayoutActive(newLayout);
+            layoutStorage.save();
+            return newLayout;
+          };
+
+          scope.removeLayout = function(layout) {
+            layoutStorage.remove(layout);
+            layoutStorage.save();
+          };
+
+          scope.makeLayoutActive = function(layout) {
+
+            var current = layoutStorage.getActiveLayout();
+
+            if (current && current.dashboard.unsavedChangeCount) {
+              var modalInstance = $uibModal.open({
+                templateUrl: 'template/SaveChangesModal.html',
+                resolve: {
+                  layout: function() {
+                    return layout;
+                  }
+                },
+                controller: 'SaveChangesModalCtrl'
+              });
+
+              // Set resolve and reject callbacks for the result promise
+              modalInstance.result.then(
+                function() {
+                  current.dashboard.saveDashboard();
+                  scope._makeLayoutActive(layout);
+                },
+                function() {
+                  scope._makeLayoutActive(layout);
+                }
+              );
+            } else {
+              scope._makeLayoutActive(layout);
+            }
+
+          };
+
+          scope._makeLayoutActive = function(layout) {
+            angular.forEach(scope.layouts, function(l) {
+              if (l !== layout) {
+                l.active = false;
+              } else {
+                l.active = true;
+              }
+            });
+            layoutStorage.save();
+          };
+
+          scope.isActive = function(layout) {
+            return !!layout.active;
+          };
+
+          scope.editTitle = function(layout) {
+            if (layout.locked) {
+              return;
+            }
+
+            var input = element.find('input[data-layout="' + layout.id + '"]');
+            layout.editingTitle = true;
+
+            $timeout(function() {
+              input.focus()[0].setSelectionRange(0, 9999);
+            });
+          };
+
+          // saves whatever is in the title input as the new title
+          scope.saveTitleEdit = function(layout) {
+            layout.editingTitle = false;
+            layoutStorage.save();
+          };
+
+          scope.options.saveLayouts = function() {
+            layoutStorage.save(true);
+          };
+          scope.options.addWidget = function() {
+            var layout = layoutStorage.getActiveLayout();
+            if (layout) {
+              layout.dashboard.addWidget.apply(layout.dashboard, arguments);
+            }
+          };
+          scope.options.loadWidgets = function() {
+            var layout = layoutStorage.getActiveLayout();
+            if (layout) {
+              layout.dashboard.loadWidgets.apply(layout.dashboard, arguments);
+            }
+          };
+          scope.options.saveDashboard = function() {
+            var layout = layoutStorage.getActiveLayout();
+            if (layout) {
+              layout.dashboard.saveDashboard.apply(layout.dashboard, arguments);
+            }
+          };
+
+          var sortableDefaults = {
+            stop: function() {
+              scope.options.saveLayouts();
+            },
+            distance: 5
+          };
+          scope.sortableOptions = angular.extend({}, sortableDefaults, scope.options.sortableOptions || {});
+        }
+      };
+    }
+  ]);
+/*
+ * Copyright (c) 2014 DataTorrent, Inc. ALL Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+angular.module('ui.dashboard')
+  .controller('SaveChangesModalCtrl', ['$scope', '$uibModalInstance', 'layout', function ($scope, $uibModalInstance, layout) {
+    
+    // add layout to scope
+    $scope.layout = layout;
+
+    $scope.ok = function () {
+      $uibModalInstance.close();
+    };
+
+    $scope.cancel = function () {
+      $uibModalInstance.dismiss();
+    };
+  }]);
+/*
+ * Copyright (c) 2014 DataTorrent, Inc. ALL Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+angular.module('ui.dashboard')
   .controller('WidgetSettingsCtrl', ['$scope', '$uibModalInstance', 'widget', function ($scope, $uibModalInstance, widget) {
     // add widget to scope
     $scope.widget = widget;
@@ -878,6 +878,11 @@ angular.module('ui.dashboard')
 
         this.widthUnits = units;
         width = parseFloat(width);
+
+        // check with min width if set, unit refer to width's unit
+        if (this.size && _.has(this.size, 'minWidth')) {
+          width = _.max([parseFloat(this.size.minWidth), width]);
+        }
 
         if (width < 0 || isNaN(width)) {
           $log.warn('malhar-angular-dashboard: setWidth was called when width was ' + width);

--- a/src/components/directives/dashboard/dashboard.js
+++ b/src/components/directives/dashboard/dashboard.js
@@ -282,6 +282,8 @@ angular.module('ui.dashboard')
         scope.options.saveDashboard = scope.externalSaveDashboard;
         scope.options.removeWidget = scope.removeWidget;
         scope.options.openWidgetSettings = scope.openWidgetSettings;
+        scope.options.clear = scope.clear;
+        scope.options.resetWidgetsToDefault = scope.resetWidgetsToDefault
 
         // save state
         scope.$on('widgetChanged', function (event) {

--- a/src/components/models/WidgetModel.js
+++ b/src/components/models/WidgetModel.js
@@ -64,6 +64,11 @@ angular.module('ui.dashboard')
         this.widthUnits = units;
         width = parseFloat(width);
 
+        // check with min width if set, unit refer to width's unit
+        if (this.size && _.has(this.size, 'minWidth')) {
+          width = _.max([parseFloat(this.size.minWidth), width]);
+        }
+
         if (width < 0 || isNaN(width)) {
           $log.warn('malhar-angular-dashboard: setWidth was called when width was ' + width);
           return false;


### PR DESCRIPTION
Client asked me to add min width for the widgets when resizing.
I think this will be a common feature people will need.
Currently it a very simple implemented min-width, the unit for comparing is always referring to the width.

Moreover, since this.style is about to deprecated so I just supported this.size.minWidth
To use this feature, add minWidth for the widget when defining it.

***
I also opened clear & resetWidgetsToDefault function to the outside of dashboard widget.
