### PR TITLE
SPOI-9924 #resolve : Hide input box upon focus lost

### DIFF
--- a/src/components/directives/dashboard/altDashboard.html
+++ b/src/components/directives/dashboard/altDashboard.html
@@ -33,8 +33,8 @@
                 <div class="widget-header panel-heading">
                     <h3 class="panel-title">
                         <span class="widget-title" ng-dblclick="editTitle(widget)" ng-hide="widget.editingTitle">{{widget.title}}</span>
-                        <form action="" class="widget-title" ng-show="widget.editingTitle" ng-submit="saveTitleEdit(widget)">
-                            <input type="text" ng-model="widget.title" class="form-control">
+                        <form action="" class="widget-title" ng-show="widget.editingTitle" ng-submit="saveTitleEdit(widget, $event)">
+                            <input type="text" ng-model="widget.title" ng-blur="titleLostFocus(widget, $event)" class="form-control">
                         </form>
                         <span class="label label-primary" ng-if="!options.hideWidgetName">{{widget.name}}</span>
                         <span ng-click="removeWidget(widget);" class="glyphicon glyphicon-remove" ng-if="!options.hideWidgetClose"></span>

--- a/src/components/directives/dashboard/dashboard.html
+++ b/src/components/directives/dashboard/dashboard.html
@@ -32,8 +32,8 @@
                 <div class="widget-header panel-heading">
                     <h3 class="panel-title">
                         <span class="widget-title" ng-dblclick="editTitle(widget)" ng-hide="widget.editingTitle">{{widget.title}}</span>
-                        <form action="" class="widget-title" ng-show="widget.editingTitle" ng-submit="saveTitleEdit(widget)">
-                            <input type="text" ng-model="widget.title" class="form-control">
+                        <form action="" class="widget-title" ng-show="widget.editingTitle" ng-submit="saveTitleEdit(widget, $event)">
+                            <input type="text" ng-model="widget.title" ng-blur="titleLostFocus(widget, $event)" class="form-control">
                         </form>
                         <span class="label label-primary" ng-if="!options.hideWidgetName">{{widget.name}}</span>
                         <span ng-click="removeWidget(widget);" class="glyphicon glyphicon-remove" ng-if="!options.hideWidgetClose"></span>

--- a/src/components/directives/dashboardLayouts/dashboardLayouts.html
+++ b/src/components/directives/dashboardLayouts/dashboardLayouts.html
@@ -2,8 +2,8 @@
     <li ng-repeat="layout in layouts" ng-class="{ active: layout.active }">
         <a ng-click="makeLayoutActive(layout)">
             <span ng-dblclick="editTitle(layout)" ng-show="!layout.editingTitle">{{layout.title}}</span>
-            <form action="" class="layout-title" ng-show="layout.editingTitle" ng-submit="saveTitleEdit(layout)">
-                <input type="text" ng-model="layout.title" class="form-control" data-layout="{{layout.id}}">
+            <form action="" class="layout-title" ng-show="layout.editingTitle" ng-submit="saveTitleEdit(layout, $event)">
+                <input type="text" ng-model="layout.title" ng-blur="titleLostFocus(layout, $event)" class="form-control" data-layout="{{layout.id}}">
             </form>
             <span ng-if="!layout.locked" ng-click="removeLayout(layout)" class="glyphicon glyphicon-remove remove-layout-icon"></span>
             <!-- <span class="glyphicon glyphicon-pencil"></span> -->

--- a/src/components/directives/dashboardLayouts/dashboardLayouts.js
+++ b/src/components/directives/dashboardLayouts/dashboardLayouts.js
@@ -108,9 +108,25 @@ angular.module('ui.dashboard')
           };
 
           // saves whatever is in the title input as the new title
-          scope.saveTitleEdit = function(layout) {
+          scope.saveTitleEdit = function(layout, event) {
             layout.editingTitle = false;
             layoutStorage.save();
+
+            // When a browser is open and the user clicks on the tab title to change it,
+            // upon pressing the Enter key, the page refreshes.
+            // This statement prevents that.
+            var evt = event || window.event;
+            if (evt) {
+              evt.preventDefault();
+            }
+          };
+
+          scope.titleLostFocus = function(layout, event) {
+            // user clicked some where; now we lost focus to the input box
+            // lets see if we need to save the title
+            if (layout.editingTitle) {
+              scope.saveTitleEdit(layout, event);
+            }
           };
 
           scope.options.saveLayouts = function() {

--- a/src/components/directives/dashboardLayouts/dashboardLayouts.spec.js
+++ b/src/components/directives/dashboardLayouts/dashboardLayouts.spec.js
@@ -293,6 +293,17 @@ describe('Directive: dashboard-layouts', function () {
       expect(LayoutStorage.prototype.save).toHaveBeenCalled();
     });
 
+    it('should call event.preventDefault', function() {
+      var layout = { id: '1' };
+      var evt = {
+        preventDefault: function() {
+        }
+      };
+      spyOn(evt, 'preventDefault');
+      childScope.saveTitleEdit(layout, evt);
+      expect(evt.preventDefault).toHaveBeenCalled();
+    })
+
   });
 
   describe('the saveLayouts method', function() {

--- a/src/components/directives/widget/DashboardWidgetCtrl.js
+++ b/src/components/directives/widget/DashboardWidgetCtrl.js
@@ -214,9 +214,25 @@ angular.module('ui.dashboard')
       };
 
       // saves whatever is in the title input as the new title
-      $scope.saveTitleEdit = function(widget) {
+      $scope.saveTitleEdit = function(widget, event) {
         widget.editingTitle = false;
         $scope.$emit('widgetChanged', widget);
+
+        // When a browser is open and the user clicks on the widget title to change it,
+        // upon pressing the Enter key, the page refreshes.
+        // This statement prevents that.
+        var evt = event || window.event;
+        if (evt) {
+          evt.preventDefault();
+        }
+      };
+
+      $scope.titleLostFocus = function(widget, event) {
+        // user clicked some where; now we lost focus to the input box
+        // lets see if we need to save the title
+        if (widget.editingTitle) {
+          $scope.saveTitleEdit(widget, event);
+        }
       };
 
       $scope.compileTemplate = function() {

--- a/src/components/directives/widget/DashboardWidgetCtrl.spec.js
+++ b/src/components/directives/widget/DashboardWidgetCtrl.spec.js
@@ -159,6 +159,17 @@ describe('Controller: DashboardWidgetCtrl', function() {
       $scope.saveTitleEdit(widget);
       expect(widget.editingTitle).toEqual(false);
     });
+
+    it('should call event preventDefault', function() {
+      var widget = { editingTitle: true };
+      var evt = {
+        preventDefault: function() {}
+      };
+      spyOn(evt, 'preventDefault');
+      $scope.saveTitleEdit(widget, evt);
+      expect(evt.preventDefault).toHaveBeenCalled();
+    });
+
   });
 
 });


### PR DESCRIPTION
1. Updated code to hide the input box when focus is lost.
2. Added code to prevent page refresh when user presses the Enter key in the input box (this only happen once for every new browser open).

The two issues above apply to dashboard layout title and widget title editing.